### PR TITLE
Only use exe directory for config on release builds

### DIFF
--- a/addons/localization_editor_plugin_g3/Dock.gd
+++ b/addons/localization_editor_plugin_g3/Dock.gd
@@ -56,14 +56,15 @@ func _ready() -> void:
 
 	_on_CloseAll()
 	
-	# if running in editor, only use res://
-	if Engine.is_editor_hint() == true:
-		get_node("%FileDialog").access = FileDialog.ACCESS_RESOURCES
-		get_node("%FileDialogNewFilePath").access = FileDialog.ACCESS_RESOURCES
-	else:
+	
+	# if running standalone, allow full filesystem
+	if OS.has_feature("release"):
 		get_node("%FileDialog").access = FileDialog.ACCESS_FILESYSTEM
 		get_node("%FileDialogNewFilePath").access = FileDialog.ACCESS_FILESYSTEM
 		_self_data_folder_path = OS.get_executable_path().get_base_dir()
+	else: # if running in editor, only use res://
+		get_node("%FileDialog").access = FileDialog.ACCESS_RESOURCES
+		get_node("%FileDialogNewFilePath").access = FileDialog.ACCESS_RESOURCES
 	
 	# create self data directory if it doesn't exist
 	var Dir := DirAccess.open("./")


### PR DESCRIPTION
This prevents the ini file from being created in Godot's exe directory while developing in editor.

Resolves #8 