### PR TITLE
Detect when recent files no longer exist

### DIFF
--- a/addons/localization_editor_plugin_g3/LinkButtonRecentFile.gd
+++ b/addons/localization_editor_plugin_g3/LinkButtonRecentFile.gd
@@ -7,13 +7,19 @@ signal removed(NodeName,f_path)
 var f_path:String
 
 func _ready() -> void:
+	var full_path : String = "%s/%s" % [
+		f_path.get_base_dir(),
+		f_path.get_file()
+	] 
+	if not FileAccess.file_exists(full_path):
+		$Lnk.disabled = true
 	$Lnk.text = "%s" % [
 		f_path.get_file()
 	]
 	
-	$Lnk.tooltip_text = "%s/%s" % [
-		f_path.get_base_dir(),
-		f_path.get_file()
+	$Lnk.tooltip_text = "%s%s" % [
+		"[NOT FOUND] " if $Lnk.disabled else "",
+		full_path
 	] 
 
 

--- a/addons/localization_editor_plugin_g3/LinkButtonRecentFile.tscn
+++ b/addons/localization_editor_plugin_g3/LinkButtonRecentFile.tscn
@@ -1,33 +1,34 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=4 format=3 uid="uid://cy0rk0nm1nwoi"]
 
-[ext_resource path="res://addons/localization_editor_plugin_g3/LinkButtonRecentFile.gd" type="Script" id=1]
-[ext_resource path="res://addons/localization_editor_plugin_g3/Ubuntu-Regular.ttf" type="FontFile" id=2]
+[ext_resource type="Script" path="res://addons/localization_editor_plugin_g3/LinkButtonRecentFile.gd" id="1"]
+[ext_resource type="FontFile" uid="uid://bj0ystwxlq2je" path="res://addons/localization_editor_plugin_g3/Ubuntu-Regular.ttf" id="2"]
 
-[sub_resource type="FontFile" id=1]
-size = 24
-font_data = ExtResource( 2 )
+[sub_resource type="FontFile" id="1"]
+fallbacks = Array[Font]([ExtResource("2")])
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/16/0/kerning_overrides/16/0 = Vector2(0, 0)
 
 [node name="LinkButton" type="HBoxContainer"]
 offset_right = 40.0
 offset_bottom = 40.0
 size_flags_horizontal = 3
 alignment = 2
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="Lnk" type="LinkButton" parent="."]
-modulate = Color( 0.745098, 0.745098, 0.745098, 1 )
-offset_right = 48.0
-offset_bottom = 40.0
+modulate = Color(0.745098, 0.745098, 0.745098, 1)
+layout_mode = 2
 size_flags_horizontal = 8
-theme_override_fonts/font = SubResource( 1 )
-focus_mode = 0
-text = "Test"
+tooltip_text = "/"
+theme_override_fonts/font = SubResource("1")
 underline = 1
 
 [node name="BtnRemove" type="Button" parent="."]
-offset_left = 52.0
-offset_right = 72.0
-offset_bottom = 40.0
+layout_mode = 2
 focus_mode = 0
 mouse_default_cursor_shape = 2
 text = "X"

--- a/project.godot
+++ b/project.godot
@@ -10,8 +10,10 @@ config_version=5
 
 [application]
 
-config/name="Localization Editor"
+config/name="Godot Localization Editor"
 run/main_scene="res://Main.tscn"
+config/use_custom_user_dir=true
+config/custom_user_dir_name="godot-localization-editor"
 config/features=PackedStringArray("4.1")
 boot_splash/bg_color=Color(0.12549, 0.145098, 0.192157, 1)
 boot_splash/show_image=false


### PR DESCRIPTION
The recent file buttons will not disable and have "[NOT FOUND]" in the tool tip when they are not detected.