### PR TITLE
Allow users to set reference language

### DIFF
--- a/addons/localization_editor_plugin_g3/Dock.gd
+++ b/addons/localization_editor_plugin_g3/Dock.gd
@@ -37,15 +37,16 @@ func _ready() -> void:
 	get_node("%LblCreditTitle").text = get_plugin_info("name")
 	get_node("%LblCreditDescription").text = get_plugin_info("description")
 
-	var i : int = 0
-	for l in Locales.LOCALES:
-		get_node("%OptionButtonAvailableLangsList").add_item(
-			"%s, %s" % [l["name"], l["code"]], i
-		)
-		get_node("%OptionButtonLangsNewFile").add_item(
-			"%s, %s" % [l["name"], l["code"]], i
-		)
-		i += 1
+	for list in get_tree().get_nodes_in_group("language_options"):
+		if not list is OptionButton:
+			continue
+		(list as OptionButton).clear()
+		var i : int = 0
+		for l in Locales.LOCALES:
+			list.add_item(
+				"%s, %s" % [l["name"], l["code"]], i
+			)
+			i += 1
 	
 	# conectar señales
 	get_node("%MenuFile").get_popup().connect("id_pressed", Callable(self, "_on_FileMenu_id_pressed"))
@@ -245,6 +246,7 @@ func _on_EditMenu_id_pressed(id:int) -> void:
 				get_node("%WindowDialogRemoveLang").popup_centered()
 		3:
 			# open program settings
+			get_node("%Preferences").set_defaults(Conf)
 			get_node("%Preferences").popup_centered()
 
 func _on_HelpMenu_id_pressed(id:int) -> void:

--- a/addons/localization_editor_plugin_g3/preference_window.gd
+++ b/addons/localization_editor_plugin_g3/preference_window.gd
@@ -26,3 +26,11 @@ func _save_and_close() -> void:
 	
 	preferences_updated.emit(preferences)
 	self.hide()
+
+
+func set_defaults(config: ConfigFile) -> void:
+	var ref_lang: String = config.get_value("main", "user_ref_lang", "en")
+	for i in range(0, _ref_lang.item_count):
+		if _ref_lang.get_item_text(i).split(', ')[1] == ref_lang:
+			_ref_lang.select(i)
+			break

--- a/addons/localization_editor_plugin_g3/preference_window.gd
+++ b/addons/localization_editor_plugin_g3/preference_window.gd
@@ -1,0 +1,28 @@
+extends Popup
+
+signal preferences_updated(preferences: Array[Dictionary])
+
+@export var _first_cell: LineEdit
+@export var _delimiter: LineEdit
+@export var _ref_lang: OptionButton
+@export var _reopen_file: CheckBox
+
+func _make_preference(key: String, value) -> Dictionary:
+	return {
+		"section": "main",
+		"key": key,
+		"value": value
+	}
+
+func _save_and_close() -> void:
+	var preferences: Array[Dictionary] = []
+	
+	# TODO: make these values file dependent or remove
+	preferences.append(_make_preference("f_cell", _first_cell.text))
+	preferences.append(_make_preference("delimiter", _delimiter.text))
+	# end TODO
+	preferences.append(_make_preference("user_ref_lang", _ref_lang.get_item_text(_ref_lang.get_selected_id())))
+	preferences.append(_make_preference("reopen_last_file", _reopen_file.button_pressed))
+	
+	preferences_updated.emit(preferences)
+	self.hide()


### PR DESCRIPTION
Includes initial refactors for the preferences/settings window. The reference language will be set from the users preference rather than the first column in the CSV.