### PR TITLE
Add delete button and rework how config files are handled

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://bv6qx8tx0i2o2"]
+[gd_scene load_steps=3 format=3 uid="uid://bv6qx8tx0i2o2"]
 
 [ext_resource type="PackedScene" uid="uid://b6km6wg3nuskc" path="res://addons/localization_editor/scenes/dock.tscn" id="1"]
+[ext_resource type="Script" path="res://addons/localization_editor/scripts/config_manager.gd" id="2_nf33b"]
 
 [node name="Main" type="Control"]
 layout_mode = 3
@@ -10,5 +11,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="Dock" parent="." instance=ExtResource("1")]
+[node name="Dock" parent="." node_paths=PackedStringArray("_config_manager") instance=ExtResource("1")]
 layout_mode = 1
+_config_manager = NodePath("../ConfigManager")
+
+[node name="ConfigManager" type="Node" parent="."]
+script = ExtResource("2_nf33b")

--- a/addons/localization_editor/icons/trash-icon.svg
+++ b/addons/localization_editor/icons/trash-icon.svg
@@ -1,7 +1,44 @@
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="SVGRepo_bgCarrier" stroke-width="0"/>
-<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
-<g id="SVGRepo_iconCarrier"> <path d="M4 6H20M16 6L15.7294 5.18807C15.4671 4.40125 15.3359 4.00784 15.0927 3.71698C14.8779 3.46013 14.6021 3.26132 14.2905 3.13878C13.9376 3 13.523 3 12.6936 3H11.3064C10.477 3 10.0624 3 9.70951 3.13878C9.39792 3.26132 9.12208 3.46013 8.90729 3.71698C8.66405 4.00784 8.53292 4.40125 8.27064 5.18807L8 6M18 6V16.2C18 17.8802 18 18.7202 17.673 19.362C17.3854 19.9265 16.9265 20.3854 16.362 20.673C15.7202 21 14.8802 21 13.2 21H10.8C9.11984 21 8.27976 21 7.63803 20.673C7.07354 20.3854 6.6146 19.9265 6.32698 19.362C6 18.7202 6 17.8802 6 16.2V6M14 10V17M10 10V17" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> </g>
-</svg>
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 1.92 1.92"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="trash-icon.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="7.79"
+     inkscape:cx="35.686778"
+     inkscape:cy="37.291399"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="584"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="m 0.1920999,0.38405096 h 1.5358002 m -0.38395,0 -0.025974,-0.0779351 c -0.025178,-0.0755249 -0.037771,-0.11328738 -0.061116,-0.14120631 -0.020618,-0.0246544 -0.047092,-0.0437377 -0.077001,-0.0555 -0.033874,-0.0133212 -0.07367,-0.0133212 -0.1532824,-0.0133212 h -0.133154 c -0.079612,0 -0.1194084,0 -0.1532814,0.0133212 -0.029909,0.0117623 -0.056386,0.0308456 -0.077003,0.0555 -0.023348,0.0279189 -0.035935,0.0656814 -0.06111,0.14120628 l -0.025978,0.0779351 m 0.9598751,0 V 1.3631236 c 0,0.1612782 0,0.2419077 -0.031388,0.3035125 -0.027606,0.054185 -0.071655,0.098234 -0.1258396,0.1258397 -0.061605,0.031388 -0.1422342,0.031388 -0.3035125,0.031388 h -0.23037 c -0.1612744,0 -0.2419116,0 -0.3035096,-0.031388 C 0.4871214,1.7648698 0.4430689,1.7208211 0.4154609,1.6666361 0.3840749,1.6050313 0.3840749,1.5244018 0.3840749,1.3631236 V 0.38405096 M 1.151975,0.76800098 V 1.4399136 M 0.768025,0.76800098 V 1.4399136"
+     stroke="#ffffff"
+     stroke-width="0.191975"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="path1" />
+</svg>

--- a/addons/localization_editor/scenes/delete_translation_popup.tscn
+++ b/addons/localization_editor/scenes/delete_translation_popup.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=2 format=3 uid="uid://clseq07nnhsan"]
+
+[ext_resource type="Script" path="res://addons/localization_editor/scripts/delete_translation_popup.gd" id="1_uwyae"]
+
+[node name="Popup" type="ConfirmationDialog" node_paths=PackedStringArray("_remember_checkbox")]
+title = "Delete Translation"
+initial_position = 2
+size = Vector2i(392, 121)
+visible = true
+ok_button_text = "Yes"
+cancel_button_text = "No"
+script = ExtResource("1_uwyae")
+_remember_checkbox = NodePath("VBoxContainer/HBoxContainer/CheckButton")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+offset_left = 8.0
+offset_top = 8.0
+offset_right = 384.0
+offset_bottom = 72.0
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Are you sure you want to delete this translation?"
+
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Remember this choice"
+
+[node name="CheckButton" type="CheckButton" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+
+[connection signal="confirmed" from="." to="." method="_on_confirmed"]

--- a/addons/localization_editor/scenes/preferences.tscn
+++ b/addons/localization_editor/scenes/preferences.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://addons/localization_editor/scripts/preference_window.gd" id="1_q5kei"]
 
-[node name="Preferences" type="Popup" node_paths=PackedStringArray("_first_cell", "_delimiter", "_ref_lang", "_reopen_file")]
+[node name="Preferences" type="Popup" node_paths=PackedStringArray("_first_cell", "_delimiter", "_ref_lang", "_reopen_file", "_delete_confirmation")]
 title = "Preferences"
 initial_position = 2
-size = Vector2i(393, 217)
+size = Vector2i(393, 252)
 visible = true
 borderless = false
 script = ExtResource("1_q5kei")
@@ -13,6 +13,7 @@ _first_cell = NodePath("MarginContainer/VBoxContainer/HBoxContainer/TxtSettingFC
 _delimiter = NodePath("MarginContainer/VBoxContainer/HBoxContainer2/OptionButton")
 _ref_lang = NodePath("MarginContainer/VBoxContainer/RefLangItemList")
 _reopen_file = NodePath("MarginContainer/VBoxContainer/CheckBoxSettingReopenFile")
+_delete_confirmation = NodePath("MarginContainer/VBoxContainer/DeleteConfirmation")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 anchors_preset = 15
@@ -807,9 +808,14 @@ layout_mode = 2
 button_pressed = true
 text = "Re-open last opened file on start"
 
+[node name="DeleteConfirmation" type="CheckBox" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Skip translation delete confirmation"
+
 [node name="Button" type="Button" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 text = "Save and Close"
 
+[connection signal="about_to_popup" from="." to="." method="_on_about_to_popup"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Button" to="." method="_save_and_close"]

--- a/addons/localization_editor/scenes/translation_entry.tscn
+++ b/addons/localization_editor/scenes/translation_entry.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=12 format=3 uid="uid://b0crqylwpgb5l"]
+[gd_scene load_steps=14 format=3 uid="uid://b0crqylwpgb5l"]
 
 [ext_resource type="Script" path="res://addons/localization_editor/scripts/translation_entry.gd" id="1_847b3"]
 [ext_resource type="PackedScene" uid="uid://cib125ol05x5u" path="res://addons/localization_editor/scenes/edit_entry_popup.tscn" id="2_1qqww"]
 [ext_resource type="Texture2D" uid="uid://ck02jgllirga2" path="res://addons/localization_editor/icons/triangle/triangle-normal.svg" id="3_5id72"]
+[ext_resource type="PackedScene" uid="uid://clseq07nnhsan" path="res://addons/localization_editor/scenes/delete_translation_popup.tscn" id="3_lf0tn"]
 [ext_resource type="Texture2D" uid="uid://d3nq4nudjmkpc" path="res://addons/localization_editor/icons/triangle/triangle-disabled.svg" id="4_t3bfu"]
 [ext_resource type="Texture2D" uid="uid://cvk18eta7ffct" path="res://addons/localization_editor/icons/triangle/triangle-outline.svg" id="5_a11t0"]
 [ext_resource type="Script" path="res://addons/localization_editor/scripts/number_input.gd" id="5_u5oxk"]
@@ -10,6 +11,7 @@
 [ext_resource type="Texture2D" uid="uid://cl2gqvw3v3f4r" path="res://addons/localization_editor/icons/edit-icon.svg" id="6_uwhd7"]
 [ext_resource type="Texture2D" uid="uid://dle24xyew1bxh" path="res://addons/localization_editor/icons/google-translate.svg" id="7_caoi8"]
 [ext_resource type="PackedScene" uid="uid://cvkoh3dmerylx" path="res://addons/localization_editor/scenes/revision_button.tscn" id="7_lw34m"]
+[ext_resource type="Texture2D" uid="uid://c3gtnt4hce7vq" path="res://addons/localization_editor/icons/trash-icon.svg" id="11_3gcht"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0ny5y"]
 bg_color = Color(0.129412, 0.14902, 0.180392, 1)
@@ -38,6 +40,9 @@ _inc_index_button = NodePath("VBoxContainer/HBox/VBxString1/HBoxContainer/Center
 [node name="EditEntryPopup" parent="." instance=ExtResource("2_1qqww")]
 visible = false
 
+[node name="Popup" parent="." instance=ExtResource("3_lf0tn")]
+visible = false
+
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
 
@@ -63,7 +68,7 @@ custom_minimum_size = Vector2(26, 26)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 10
-disabled = true
+mouse_default_cursor_shape = 2
 texture_normal = ExtResource("3_5id72")
 texture_pressed = ExtResource("4_t3bfu")
 texture_hover = ExtResource("5_a11t0")
@@ -121,7 +126,7 @@ custom_minimum_size = Vector2(26, 26)
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 2
-disabled = true
+mouse_default_cursor_shape = 2
 texture_normal = ExtResource("3_5id72")
 texture_pressed = ExtResource("4_t3bfu")
 texture_hover = ExtResource("5_a11t0")
@@ -153,6 +158,14 @@ expand_icon = true
 [node name="Button" parent="VBoxContainer/HBox/VBxString1/HBoxContainer" instance=ExtResource("7_lw34m")]
 layout_mode = 2
 
+[node name="DeleteButton" type="Button" parent="VBoxContainer/HBox/VBxString1/HBoxContainer"]
+custom_minimum_size = Vector2(30, 0)
+layout_mode = 2
+tooltip_text = "Edit Translation"
+icon = ExtResource("11_3gcht")
+icon_alignment = 1
+expand_icon = true
+
 [node name="EditButton" type="Button" parent="VBoxContainer/HBox/VBxString1/HBoxContainer"]
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
@@ -170,6 +183,7 @@ layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_0ny5y")
 
 [connection signal="entry_updated" from="EditEntryPopup" to="." method="_on_entry_updated"]
+[connection signal="delete_confirmed" from="Popup" to="." method="_on_delete_confirmed"]
 [connection signal="pressed" from="VBoxContainer/HBox/VBxString1/HBoxContainer3/CenterContainer/TextureButton" to="." method="_on_change_index_pressed" binds= [true]]
 [connection signal="focus_entered" from="VBoxContainer/HBox/VBxString1/HBoxContainer2/NumberInput" to="VBoxContainer/HBox/VBxString1/HBoxContainer2/NumberInput" method="_on_focus_entered"]
 [connection signal="focus_exited" from="VBoxContainer/HBox/VBxString1/HBoxContainer2/NumberInput" to="VBoxContainer/HBox/VBxString1/HBoxContainer2/NumberInput" method="_on_focus_exited"]
@@ -180,4 +194,5 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_0ny5y")
 [connection signal="pressed" from="VBoxContainer/HBox/VBxString1/HBoxContainer/CenterContainer/TextureButton2" to="." method="_on_change_index_pressed" binds= [false]]
 [connection signal="pressed" from="VBoxContainer/HBox/VBxString1/HBoxContainer/BtnTranslate" to="." method="_on_translate_button_pressed"]
 [connection signal="toggled" from="VBoxContainer/HBox/VBxString1/HBoxContainer/Button" to="." method="_on_needs_revision_toggled"]
+[connection signal="pressed" from="VBoxContainer/HBox/VBxString1/HBoxContainer/DeleteButton" to="." method="_on_delete_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBox/VBxString1/HBoxContainer/EditButton" to="." method="_on_edit_button_pressed"]

--- a/addons/localization_editor/scripts/config_manager.gd
+++ b/addons/localization_editor/scripts/config_manager.gd
@@ -1,0 +1,81 @@
+@tool
+extends Node
+
+signal initialized
+
+# where user preferences are stored
+const _settings_file : String = "user://settings.ini"
+# where file specific data is stored
+const _data_file_name: String = ".gle-data"
+
+var is_initialized := false
+
+var _user_config := ConfigFile.new()
+var _directory_config := ConfigFile.new()
+
+var _current_file : String
+var _directory_config_path: String:
+	get:
+		return "%s/%s" % [_current_file.get_base_dir(), _data_file_name]
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	if FileAccess.file_exists(_settings_file):
+		_user_config.load(_settings_file)
+	is_initialized = true
+	initialized.emit()
+
+func _save_settings_config(_is_init_step := false) -> void:
+	if not is_initialized and not _is_init_step:
+		return
+	_user_config.save(_settings_file)
+
+func _save_directory_config() -> void:
+	_directory_config.save(_directory_config_path)
+
+func set_new_file(new_file: String) -> void:
+	_current_file = new_file
+	if FileAccess.file_exists(_directory_config_path):
+		_directory_config.load(_directory_config_path)
+	else:
+		_directory_config = ConfigFile.new()
+		_save_directory_config()
+
+func get_key_value(translation_key: String, config_key: String, default: Variant = null) -> Variant:
+	var section_key := "%s/%s" % [_current_file.get_file(), translation_key]
+	return _directory_config.get_value(section_key, config_key, default)
+
+func set_key_value(translation_key: String, config_key: String, value: Variant) -> void:
+	var section_key := "%s/%s" % [_current_file.get_file(), translation_key]
+	_directory_config.set_value(section_key, config_key, value)
+	_save_directory_config()
+
+func replace_key(old_key: String, new_key: String) -> void:
+	var old_section_key := "%s/%s" % [_current_file.get_file(), old_key]
+	var new_section_key := "%s/%s" % [_current_file.get_file(), new_key]
+	for key in _directory_config.get_section_keys(old_section_key):
+		var old_value = _directory_config.get_value(old_section_key, key)
+		_directory_config.set_value(new_section_key, key, old_value)
+	_directory_config.erase_section(old_section_key)
+	_save_directory_config()
+
+func get_file_value(key: String, default: Variant = null) -> Variant:
+	return _directory_config.get_value(_current_file.get_file(), key, default)
+
+func set_file_value(key: String, value: Variant) -> void:
+	_directory_config.set_value(_current_file.get_file(), key, value)
+	_save_directory_config()
+
+func get_directory_value(section: String, key: String, default: Variant = null) -> Variant:
+	return _directory_config.get_value(section, key, default)
+
+func set_directory_value(section: String, key: String, value: Variant) -> void:
+	_directory_config.set_value(section, key, value)
+	_save_directory_config()
+
+func get_settings_value(section: String, key: String, default: Variant = null) -> Variant:
+	return _user_config.get_value(section, key, default)
+
+func set_settings_value(section: String, key: String, value: Variant) -> void:
+	_user_config.set_value(section, key, value)
+	_save_settings_config()

--- a/addons/localization_editor/scripts/delete_translation_popup.gd
+++ b/addons/localization_editor/scripts/delete_translation_popup.gd
@@ -1,0 +1,10 @@
+@tool
+extends ConfirmationDialog
+
+signal delete_confirmed(remember_choice: bool)
+
+@export var _remember_checkbox: CheckButton
+
+
+func _on_confirmed() -> void:
+	delete_confirmed.emit(_remember_checkbox.button_pressed)

--- a/addons/localization_editor/scripts/preference_window.gd
+++ b/addons/localization_editor/scripts/preference_window.gd
@@ -1,30 +1,22 @@
 @tool
 extends Popup
 
-signal preferences_updated(preferences: Array[Dictionary])
-
 @export var _first_cell: LineEdit
 @export var _delimiter: OptionButton
 @export var _ref_lang: OptionButton
 @export var _reopen_file: CheckBox
+@export var _delete_confirmation: CheckBox
 
-func _make_preference(key: String, value) -> Dictionary:
-	return {
-		"section": "main",
-		"key": key,
-		"value": value
-	}
+@onready var _config_manager: Node = get_node("/root/Main/ConfigManager")
+
 
 func _save_and_close() -> void:
-	var preferences: Array[Dictionary] = []
-	
-	preferences.append(_make_preference("first_cell", _first_cell.text))
-	preferences.append(_make_preference("delimiter", _get_delimiter_value()))
+	_config_manager.set_settings_value("main", "first_cell", _first_cell.text)
+	_config_manager.set_settings_value("main", "delimiter", _get_delimiter_value())
 	var ref_lang: String = _ref_lang.get_item_text(_ref_lang.get_selected_id()).split(", ")[1]
-	preferences.append(_make_preference("user_ref_lang", ref_lang))
-	preferences.append(_make_preference("reopen_last_file", _reopen_file.button_pressed))
-	
-	preferences_updated.emit(preferences)
+	_config_manager.set_settings_value("main", "user_ref_lang", ref_lang)
+	_config_manager.set_settings_value("main", "reopen_last_file", _reopen_file.button_pressed)
+	_config_manager.set_settings_value("main", "no_confirm_delete", _delete_confirmation.button_pressed)
 	self.hide()
 
 
@@ -38,18 +30,19 @@ func _get_delimiter_value():
 			return ","
 
 
-func set_defaults(config: ConfigFile) -> void:
-	var ref_lang: String = config.get_value("main", "user_ref_lang", "en")
+func _on_about_to_popup():
+	var ref_lang: String = _config_manager.get_settings_value("main", "user_ref_lang", "en")
 	for i in range(0, _ref_lang.item_count):
 		if _ref_lang.get_item_text(i).split(", ")[1] == ref_lang:
 			_ref_lang.select(i)
 			break
-	_first_cell.text = config.get_value("main", "first_cell", "keys")
-	match config.get_value("main", "delimiter", ","):
+	_first_cell.text = _config_manager.get_settings_value("main", "first_cell", "keys")
+	match _config_manager.get_settings_value("main", "delimiter", ","):
 		";":
 			_delimiter.select(1)
 		"	":
 			_delimiter.select(2)
 		_:
 			_delimiter.select(0)
-	_reopen_file.button_pressed = config.get_value("main", "reopen_last_file", true)
+	_reopen_file.button_pressed = _config_manager.get_settings_value("main", "reopen_last_file", true)
+	_delete_confirmation.button_pressed = _config_manager.get_settings_value("main", "no_confirm_delete", false)

--- a/addons/localization_editor/scripts/translation_list.gd
+++ b/addons/localization_editor/scripts/translation_list.gd
@@ -5,10 +5,13 @@ signal translation_requested(source_lang: String, source_text: String,
 	target_lang: String, target_text: String, callback: Callable)
 signal entry_updated(new_data: Dictionary)
 signal entry_added(new_data: Dictionary)
+signal entry_deleted(key: String)
 
 @export var _translation_entry_scene: PackedScene
 @export var _reference_lang_option: OptionButton
 @export var _translated_lang_option: OptionButton
+
+@onready var _config_manager: Node = get_node("/root/Main/ConfigManager")
 
 const _google_translate_path: String = "res://addons/localization_editor/google_translate/google_translate.tscn"
 var _google_translate: Node
@@ -18,16 +21,16 @@ func _ready():
 		_google_translate = load(_google_translate_path).instantiate()
 		get_node("/root/Main/Dock").add_child.call_deferred(_google_translate)
 
-func init_list(translation_data: Dictionary, config: ConfigFile, current_file: String) -> void:
+func init_list(translation_data: Dictionary) -> void:
 	# reset list
 	for child in get_children():
-		child.remove()
+		child.remove(true)
 	
 	# wait a frame for entries to be removed
 	await get_tree().process_frame
 	
 	for key in translation_data:
-		_add_entry_internal(key, translation_data[key], config, current_file)
+		_add_entry_internal(key, translation_data[key])
 	
 	# wait a frame for entries to be loaded
 	await get_tree().process_frame
@@ -42,36 +45,35 @@ func update_target_language(new_lang: String) -> void:
 	for child in get_children():
 		child.update_target_language(new_lang)
 
-func add_entry(key: String, ref_text: String, target_text: String,
-		config: ConfigFile, current_file: String) -> void:
+func add_entry(key: String, ref_text: String, target_text: String) -> void:
 	var selected_reference := _reference_lang_option.get_item_text(_reference_lang_option.selected)
 	var selected_translated := _translated_lang_option.get_item_text(_translated_lang_option.selected)
 	var translations : Dictionary = {
 		selected_reference: ref_text,
 		selected_translated: target_text
 	}
-	var new_entry = _add_entry_internal(key, translations, config, current_file, true)
+	var new_entry = _add_entry_internal(key, translations, true)
 	await get_tree().process_frame
 	entry_added.emit(new_entry.get_entry_data())
 	new_entry.set_init_complete()
 	
 
 func _add_entry_internal(key: String, entry_data: Dictionary,
-		config: ConfigFile, current_file: String, focus: bool = false) -> Node:
+		focus: bool = false) -> Node:
 	var selected_reference := _reference_lang_option.get_item_text(_reference_lang_option.selected)
 	var selected_translated := _translated_lang_option.get_item_text(_translated_lang_option.selected)
 	var translation_entry = _translation_entry_scene.instantiate()
 	if _google_translate != null:
 		translation_entry.translation_requested.connect(_on_translate_requested)
 	translation_entry.data_changed.connect(_on_entry_updated)
-	var config_section := "%s/%s" % [current_file, key]
+	translation_entry.removed.connect(_on_entry_deleted)
 	translation_entry.set_translation_data(
 		key,
 		selected_reference,
 		selected_translated,
 		entry_data,
-		config.get_value(config_section, "notes", ""),
-		config.get_value(config_section, "needs_revision", false),
+		_config_manager.get_key_value(key, "notes", ""),
+		_config_manager.get_key_value(key, "needs_revision", false),
 		focus,
 		_google_translate != null
 	)
@@ -89,3 +91,6 @@ func _on_translate_requested(source_lang: String, source_text: String,
 
 func _on_entry_updated(new_data: Dictionary) -> void:
 	entry_updated.emit(new_data)
+
+func _on_entry_deleted(key: String) -> void:
+	entry_deleted.emit(key)


### PR DESCRIPTION
I decided to rework how config files are handled to make it easier to work with and less linking via signals. I did not see any memory impact by using `@onready get_node` in all the entries, but we can refactor down the line if it becomes an issue.

Entries can now be deleted.
The confirmation dialog can be hidden for subsequent deletes.